### PR TITLE
Drop ESC sequences to keep test result readable

### DIFF
--- a/start_point/cyber-dojo.sh
+++ b/start_point/cyber-dojo.sh
@@ -3,9 +3,7 @@
 CLASSES=.:`ls /usr/share/kotlin/kotlinc/lib/*.jar | tr '\n' ':'`
 CLASSES=`ls /kotlin/*.jar | tr '\n' ':'`${CLASSES}
 kotlinc *.kt -include-runtime -cp $CLASSES
+EXECUTE_TEST="java -cp $CLASSES io.kotlintest.runner.console.LauncherKt --writer basic --spec hiker.HikerTest"
 if [ $? -eq 0 ]; then
-  java -cp $CLASSES \
-    io.kotlintest.runner.console.LauncherKt \
-    --writer basic \
-    --spec hiker.HikerTest  # [X]
+   $EXECUTE_TEST | sed 's/\x1b\[[0-9;]*m//g'
 fi


### PR DESCRIPTION
There is no way we are aware of to prevent kotlintest writing ESC sequences to switch output color in the terminal.
The used terminal does not alter font color in accordence to ESC sequences.
To keep the output tidy and readable, drop all ESC sequences for color manipulation of the used font.